### PR TITLE
feat: local account creation on linux machine so local admin works

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 An ansible role to install and configure OpenVPN AS
 
+
+## Pre-Reqs
+If running on MacOS, following packages will need to be installed
+
+- passlib python module
+
 ## Example Playbook
 
 ```yaml

--- a/tasks/config-openvpn-core.yml
+++ b/tasks/config-openvpn-core.yml
@@ -1,4 +1,32 @@
 ---
+- name: Create admin pam account
+  user:
+    name: '{{ admin_user }}'
+    comment: 'OpenVPNAS Admin Account'
+    createhome: no
+    shell: "/sbin/nologin"
+    password: "{{ admin_password | password_hash('sha512') }}"
+    state: present
+  when: >
+    (create_admin_account|bool)
+    and (admin_user is defined)
+    and (admin_user|length > 0)
+    and (admin_password is defined)
+    and (admin_password|length > 0)
+    and not admin_user_present
+- name: Update openvpnas about PAM user account change
+  lineinfile:
+    path: /usr/local/openvpn_as/etc/as.conf
+    state: present
+    regexp: '^boot_pam_users.0=openvpn'
+    line: 'boot_pam_users.0={{ admin_user }}'
+  notify:
+    - Reload service openvpnas
+  when: >
+    (create_admin_account|bool)
+    and (admin_user is defined)
+    and (admin_user|length > 0)
+    and not admin_user_present
 - name: Create admin user
   command: >
     /usr/local/openvpn_as/scripts/sacli


### PR DESCRIPTION
This is needed, once you enable LDAP authentication you have to have a bootstrap admin account for logging into the admin console